### PR TITLE
Added indices for the "executable"

### DIFF
--- a/mysql/software-tracker-db.yaml
+++ b/mysql/software-tracker-db.yaml
@@ -28,6 +28,8 @@ initdbScripts:
     UNIQUE KEY `uuid` (`uuid`),
     KEY `user` (`user`),
     KEY `image` (`image`),
+    KEY `executable` (`executable`),
     KEY `timestamp` (`timestamp`),
-    KEY `user_2` (`user`,`image`,`timestamp`)
+    KEY `user_image` (`user`,`image`,`timestamp`),
+    KEY `user_executable` (`user`,`executable`,`timestamp`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
I tend to query paso by the executable name. Most of my queries spanning more than 1 or 2 months of data used to fail because of a timeout.
I added these two indices to the prod server and now it's super quick ! e.g. <http://paso.tol.sanger.ac.uk/query?after=2024-09-01&format=html&executable=interproscan.sh&aggregate=user>